### PR TITLE
Support for Laravel 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # laravel-uuid
-Eloquent UUID Trait for Laravel 5.7, 5.8, 6.0 and 7.0.
+Eloquent UUID Trait for Laravel 5.7 and above.
 
 [![Travis](https://img.shields.io/travis/JamesHemery/laravel-uuid.svg?style=for-the-badge)](https://travis-ci.org/JamesHemery/laravel-uuid)
 [![Total Downloads](https://img.shields.io/packagist/dt/jamesh/laravel-uuid.svg?style=for-the-badge)](https://packagist.org/packages/jamesh/laravel-uuid)

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "jamesh/laravel-uuid",
-    "description": "Eloquent UUID Trait for Laravel 5.7, 5.8 and 6.0.",
+    "description": "Eloquent UUID Trait for Laravel 5.7 and above.",
     "type": "plugin",
     "license": "MIT",
     "authors": [
@@ -12,8 +12,8 @@
     "minimum-stability": "stable",
     "require": {
         "php" : "^7.2",
-        "illuminate/support": "^5.7|^5.8|^6.0|^7",
-        "illuminate/database": "^5.7|^5.8|^6.0|^7"
+        "illuminate/support": "^5.7|^6|^7|^8",
+        "illuminate/database": "^5.7|^6|^7|^8"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.0|^8.0",


### PR DESCRIPTION
Hey mate, just a quick one to add support for Laravel 8.

I've also updated the README and Composer description to indicate support for Laravel 5.7+ (so you don't have to specify each version individually, and as I don't foresee any trouble with your package for future Laravel versions), and cleaned up version support in `composer.json` a bit.